### PR TITLE
Fix crash when pwads folder is empty or doesn't exist

### DIFF
--- a/t_text.c
+++ b/t_text.c
@@ -544,6 +544,7 @@ void T_InitWads()
 	// copy & free
 	memcpy(&iwad, &iwad_list[wad_pick], sizeof(iwad_item_t));
 	Z_Free(iwad_list);
+	wad_pick = 0;
 
 	// pick PWAD(s)
 	if(iwad.allow_pwads)
@@ -551,7 +552,6 @@ void T_InitWads()
 	else
 	{
 		wad_count = 0;
-		wad_pick = 0;
 	}
 
 	memset(screens[0] + 144 * SCREENWIDTH, 0, SCREENWIDTH * SCREENHEIGHT - 144 * SCREENWIDTH);
@@ -559,7 +559,6 @@ void T_InitWads()
 
 	if(wad_count > 0)
 	{
-		wad_pick = 0;
 		txt_color = 7;
 
 		for(i = 0, yy = 160; i < wad_count; i++, yy += 32)


### PR DESCRIPTION
So I have root-caused both of these PR's (https://github.com/kgsws/kgdoom/pull/4 & https://github.com/kgsws/kgdoom/pull/5) to the same issue.  When the folder, `/sd/switch/kgdoom/pwads` is empty or otherwise doesn't exist, the variable wad_pick doesn't get reset to 0.  So if an entry other than the first  is selected, an attempt is made to load a non-existent pwad.